### PR TITLE
fix: add timeout handling for LLM calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,12 +45,12 @@ python cli/review_pr.py
 
 ## Core Functions
 
-### `generate_fix(code, issue)`
+### `generate_fix(llm, code, issue, timeout_seconds=30)`
 
 Generates a fixed version of code using the LLM based on the identified issue.
 
 ```python
-def generate_fix(code, issue):
+def generate_fix(llm, code, issue, timeout_seconds=30):
     prompt = f"""
 You are a senior engineer.
 
@@ -65,15 +65,16 @@ Code:
 Return ONLY the fixed code.
 No explanation.
 """
-    return ask_llm(prompt)
+    return ask_llm(prompt)  # Returns original code if the LLM fails or times out
 ```
 
 **Parameters:**
 - `code` (str): The problematic code to fix
 - `issue` (str): Description of the issue to fix
+- `timeout_seconds` (int | float | None): Maximum time to wait for the LLM call. Use `None` to disable the timeout.
 
 **Returns:**
-- (str): Fixed code from the LLM
+- (str): Fixed code from the LLM, or the original code if the LLM call fails or times out
 
 ### `format_suggestion(fixed_code)`
 

--- a/bot/fixer.py
+++ b/bot/fixer.py
@@ -1,4 +1,36 @@
-def generate_fix(llm, code, issue):
+from queue import Queue
+from threading import Thread
+
+DEFAULT_LLM_TIMEOUT_SECONDS = 30
+
+
+def _call_llm_with_timeout(llm, prompt, timeout_seconds=DEFAULT_LLM_TIMEOUT_SECONDS):
+    """Call an LLM function with a bounded wait and clear error handling."""
+    if timeout_seconds is None:
+        return llm(prompt)
+
+    result_queue = Queue(maxsize=1)
+
+    def run_llm():
+        try:
+            result_queue.put((True, llm(prompt)))
+        except Exception as exc:
+            result_queue.put((False, exc))
+
+    worker = Thread(target=run_llm, daemon=True)
+    worker.start()
+    worker.join(timeout_seconds)
+
+    if worker.is_alive():
+        raise TimeoutError(f"LLM call timed out after {timeout_seconds} seconds")
+
+    succeeded, result = result_queue.get()
+    if succeeded:
+        return result
+    raise result
+
+
+def generate_fix(llm, code, issue, timeout_seconds=DEFAULT_LLM_TIMEOUT_SECONDS):
     prompt = f"""
 You are a senior engineer.
 
@@ -12,9 +44,13 @@ Code:
 
 Return ONLY the fixed code.
 """
-    return llm(prompt)
+    try:
+        return _call_llm_with_timeout(llm, prompt, timeout_seconds)
+    except Exception:
+        return code
 
-def validate_fix(llm, original, fix):
+
+def validate_fix(llm, original, fix, timeout_seconds=DEFAULT_LLM_TIMEOUT_SECONDS):
     prompt = f"""
 Check if the fix correctly resolves the issue.
 
@@ -26,8 +62,13 @@ Fix:
 
 Answer YES or NO only.
 """
-    result = llm(prompt)
-    return "YES" in result.upper()
+    try:
+        result = _call_llm_with_timeout(llm, prompt, timeout_seconds)
+    except Exception:
+        return False
+
+    return "YES" in str(result).upper()
+
 
 def format_suggestion(fixed_code):
     return f"""```suggestion

--- a/tests/test_fixer_timeout.py
+++ b/tests/test_fixer_timeout.py
@@ -1,0 +1,48 @@
+import time
+import unittest
+
+from bot.fixer import generate_fix, validate_fix
+
+
+class TestFixerTimeoutHandling(unittest.TestCase):
+    def test_generate_fix_returns_llm_output_when_call_succeeds(self):
+        def llm(prompt):
+            self.assertIn("Fix the issue", prompt)
+            return "fixed code"
+
+        self.assertEqual(generate_fix(llm, "bad code", "bug"), "fixed code")
+
+    def test_generate_fix_returns_original_code_when_llm_times_out(self):
+        def slow_llm(prompt):
+            time.sleep(0.05)
+            return "late fix"
+
+        original_code = "bad code"
+        self.assertEqual(
+            generate_fix(slow_llm, original_code, "bug", timeout_seconds=0.01),
+            original_code,
+        )
+
+    def test_generate_fix_returns_original_code_when_llm_raises(self):
+        def failing_llm(prompt):
+            raise RuntimeError("LLM unavailable")
+
+        original_code = "bad code"
+        self.assertEqual(generate_fix(failing_llm, original_code, "bug"), original_code)
+
+    def test_validate_fix_returns_false_when_llm_times_out(self):
+        def slow_llm(prompt):
+            time.sleep(0.05)
+            return "YES"
+
+        self.assertFalse(validate_fix(slow_llm, "bad", "fixed", timeout_seconds=0.01))
+
+    def test_validate_fix_returns_false_when_llm_raises(self):
+        def failing_llm(prompt):
+            raise RuntimeError("LLM unavailable")
+
+        self.assertFalse(validate_fix(failing_llm, "bad", "fixed"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Add a default 30-second timeout around LLM calls used by `generate_fix` and `validate_fix`
- Return safe fallback values when the LLM call times out or raises an exception
- Document the optional `timeout_seconds` argument and add focused timeout/error tests

Closes #25.

## Testing

- `python3 -m unittest tests.test_fixer_timeout -v`
- `python3 -m py_compile bot/fixer.py`
- `git diff --check`